### PR TITLE
Enforce registry rules — disable Install button for non-conforming plugins

### DIFF
--- a/REGISTRY-RULES.md
+++ b/REGISTRY-RULES.md
@@ -1,0 +1,97 @@
+# Plugin / Theme Registry Rules
+
+`e_PLUGIN/pluginpack.xml` (and `e_THEME/themepack.xml`) is the curated
+registry that powers the **Find Plugins** / **Find Themes** screens in the
+Plugin Manager. Each `<plugin>` entry points at a public GitHub repository
+that contributes a single addon. These rules describe what an entry — and
+the repo it points at — must look like for the entry to be installable.
+
+## Validation rules
+
+Every entry in `pluginpack.xml` must satisfy:
+
+1. **`plugin.xml` is at the expected path.**
+   The Plugin Manager fetches:
+
+   ```
+   https://raw.githubusercontent.com/{organization}/{repo}/refs/heads/{branch}/e107_plugins/{folder}/plugin.xml
+   ```
+
+   The repository must keep `plugin.xml` at `e107_plugins/{folder}/plugin.xml`,
+   not at the repo root.
+
+2. **`plugin.xml` declares required root attributes.**
+   The `<plugin>` root element must define both `name` and `version`. A
+   missing or empty attribute will block install.
+
+3. **`<author>` element is present.**
+   `plugin.xml` should declare `<author name="…" url="…"/>` so the
+   marketplace card can attribute the work.
+
+4. **`folder` in `pluginpack.xml` matches the actual directory in the
+   repo.** A mismatch produces the same 404 as rule 1.
+
+5. **`branch` exists on the remote repo.** Defaults to `main`.
+
+6. **Repo is public** and the download `.zip` is reachable via
+   `https://github.com/{org}/{repo}/archive/refs/heads/{branch}.zip`.
+
+7. **Plugin installs cleanly** on a stock e107 install, with no conflicts
+   against core tables, prefs, or other registry entries.
+
+8. **Open-source licence** compatible with e107's GPL.
+
+Rules 1–2 are checked at runtime (see *What happens if rules are not met*
+below). Rules 3–8 remain manual review checks during the `pluginpack.xml`
+PR.
+
+## Minimal valid `<plugin>` entry (in `pluginpack.xml`)
+
+```xml
+<plugin
+    folder="myplugin"
+    organization="e107-Plugins"
+    repo="myplugin"
+    branch="main"
+    name="My Plugin"
+    compatibility="2.3">
+    <description>One-line summary shown on the Find Plugins card.</description>
+</plugin>
+```
+
+Required attributes: `folder`, `organization`, `repo`. Optional but
+strongly recommended: `branch` (defaults to `main`), `name`,
+`compatibility`, and a `<description>` child element.
+
+## Minimal valid `plugin.xml` (in the contributor's repo, at
+`e107_plugins/{folder}/plugin.xml`)
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<plugin name="My Plugin" version="1.0.0" date="2026-01-15" compatibility="2.3">
+    <author name="Jane Doe" url="https://example.com/jane"/>
+    <description>Full description shown on the Find Plugins card.</description>
+    <category>tools</category>
+</plugin>
+```
+
+The `name` and `version` root attributes are mandatory — the runtime guard
+will refuse to enable the Install button without them.
+
+## What happens if rules are not met
+
+When the Plugin Manager renders the Find Plugins screen, it fetches each
+entry's remote `plugin.xml`. If the fetch fails (rule 1, 4, or 5) or the
+payload is missing required fields (rule 2), the card still renders using
+whatever data `pluginpack.xml` supplies, but the **Install button is
+disabled** and its tooltip explains why:
+
+* `plugin.xml not found at expected path (e107_plugins/{folder}/plugin.xml)`
+  — the fetch returned 404 or unparseable XML.
+* `plugin.xml is missing required fields: name, version` — at least one of
+  the required `<plugin>` root attributes is empty or absent.
+
+Other users see the entry exists but cannot trigger an install that would
+fail mid-flight. To re-enable a card, fix the repo (move `plugin.xml`
+under `e107_plugins/{folder}/`, add the missing attributes) or correct
+the registry entry, then resubmit a `pluginpack.xml` PR.

--- a/eadmin/plugin.php
+++ b/eadmin/plugin.php
@@ -1838,7 +1838,19 @@ class plugin_form_online_ui extends e_admin_form_ui
 			return '&nbsp; <span class="label label-default">'.LAN_INSTALLED."</span>";
 			return null;
 		}
- 
+
+		// Registry-rules runtime gate — disable Install when remote plugin.xml is missing or invalid.
+		if(isset($data['installable']) && $data['installable'] === false)
+		{
+			$tp       = e107::getParser();
+			$errAttr  = $tp->toAttribute(isset($data['install_error']) ? $data['install_error'] : '');
+			$label    = defset('LAN_PLUGIN_INSTALL_UNAVAILABLE', 'Install');
+			$btnClass = ($action === 'grid') ? 'btn btn-sm btn-warning' : 'btn btn-sm btn-default btn-secondary';
+			$inner    = ($action === 'grid') ? ($tp->toGlyph('fa-bolt').$label) : ADMIN_INSTALLPLUGIN_ICON;
+
+			return '<button type="button" class="'.$btnClass.'" disabled title="'.$errAttr.'">'.$inner.'</button>';
+		}
+
 
 		$id = 'plug_'.$data['params']['id'];
 		$modalCaption = (!empty($data['price'])) ? EPL_ADLAN_92." ".$data['name']." ".$data['version'] : EPL_ADLAN_230." ".$data['name']." ".$data['version'];

--- a/ehandlers/e_marketplace.php
+++ b/ehandlers/e_marketplace.php
@@ -157,7 +157,16 @@ class e_marketplace
  
 			// Fetch remote plugin.xml — version, author, icon, category, date
 			$remote = $this->fetchRemotePluginXml($org, $repo, $branch, $folder, $type);
- 
+
+			// Registry-rules runtime gate — see REGISTRY-RULES.md
+			$installable  = $this->validateRemote($remote);
+			$installError = $installable ? '' : $this->getValidationError($remote, $folder);
+
+			if (!$installable)
+			{
+				e107::getMessage()->addDebug('pluginpack: entry "' . $folder . '" not installable — ' . $installError);
+			}
+
 			// plugin.xml wins over registry for shared fields
 			$name         = (!empty($remote['name']))          ? $remote['name']          : $registryName;
 			$desc         = (!empty($remote['description']))   ? $remote['description']   : $registryDesc;
@@ -187,6 +196,8 @@ class e_marketplace
 				'screenshots'   => '',
 				'livedemo'      => '',
 				'price'         => '',
+				'installable'   => $installable,
+				'install_error' => $installError,
 				'params'        => array(
 					'organization' => $org,
 					'repo'         => $repo,
@@ -200,8 +211,69 @@ class e_marketplace
 		}
 
 		$result['params']['count'] = $i;
- 
+
 		return $result;
+	}
+
+
+	/**
+	 * Check that a remote plugin.xml payload satisfies the runtime registry rules.
+	 * Returns false for null/empty/non-array input or when required fields are missing.
+	 *
+	 * @param  mixed $remote  Result from fetchRemotePluginXml()
+	 * @return bool
+	 */
+	private function validateRemote($remote)
+	{
+		if (empty($remote) || !is_array($remote))
+		{
+			return false;
+		}
+
+		if (empty($remote['name']) || empty($remote['version']))
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Human-readable validation error for the disabled Install button tooltip.
+	 *
+	 * @param  mixed  $remote  Result from fetchRemotePluginXml()
+	 * @param  string $folder  Registry folder (used in the not-found message)
+	 * @return string          Empty string if $remote is valid
+	 */
+	private function getValidationError($remote, $folder = '{folder}')
+	{
+		if (empty($remote) || !is_array($remote))
+		{
+			$path = 'e107_plugins/' . $folder . '/plugin.xml';
+			$msg  = defset('LAN_PLUGIN_REGISTRY_XML_NOT_FOUND', 'plugin.xml not found at expected path ([x])');
+			return str_replace('[x]', $path, $msg);
+		}
+
+		$missing = array();
+
+		if (empty($remote['name']))
+		{
+			$missing[] = 'name';
+		}
+
+		if (empty($remote['version']))
+		{
+			$missing[] = 'version';
+		}
+
+		if (empty($missing))
+		{
+			return '';
+		}
+
+		$msg = defset('LAN_PLUGIN_REGISTRY_XML_MISSING_FIELDS', 'plugin.xml is missing required fields: [x]');
+		return str_replace('[x]', implode(', ', $missing), $msg);
 	}
 
 

--- a/elanguages/English/admin/lan_plugin.php
+++ b/elanguages/English/admin/lan_plugin.php
@@ -266,4 +266,7 @@ return [
     'EPL_ADLAN_255' => "Overwrite Files",
     'EPL_ADLAN_256' => "Skipped [x] (already exists)",
     'EPL_ADLAN_257' => "Readonly",
+    'LAN_PLUGIN_REGISTRY_XML_NOT_FOUND'      => "plugin.xml not found at expected path ([x])",
+    'LAN_PLUGIN_REGISTRY_XML_MISSING_FIELDS' => "plugin.xml is missing required fields: [x]",
+    'LAN_PLUGIN_INSTALL_UNAVAILABLE'         => "Install",
 ];


### PR DESCRIPTION
## Summary

When the remote `plugin.xml` for a `pluginpack.xml` entry is missing (404 at `e107_plugins/{folder}/plugin.xml`) or lacks required root attributes, the Find Plugins card still renders but the **Install button is disabled** with a tooltip explaining why. Prevents users from triggering installs that would fail mid-flight.

Implements the runtime guard described in the parent issue (#32), addressing the concrete bug where `e107-Kanonimpresor/sitedown` is listed in `pluginpack.xml` with `plugin.xml` at the repo root instead of `e107_plugins/sitedown_styles/plugin.xml`.

## Changes

- **`ehandlers/e_marketplace.php`**
  - New private `validateRemote($remote)` — returns `false` for null / non-array / missing `name` / missing `version`.
  - New private `getValidationError($remote, $folder)` — human-readable tooltip text (uses LAN constants with defset fallback).
  - `parseRegistry()` now sets `installable` (bool) and `install_error` (string) on every `$xdata['data'][n]` entry. Backwards-compatible — existing callers ignore unknown keys.
  - Debug message logged via `e107::getMessage()->addDebug()` when an entry fails the gate.

- **`eadmin/plugin.php`** — `plugin_form_online_ui::options()` branches on `$data['installable']`; renders a disabled `<button>` with the validation message as `title=` when `false`. The existing active Install button is unchanged for valid entries.

- **`elanguages/English/admin/lan_plugin.php`** — three new LAN keys: `LAN_PLUGIN_REGISTRY_XML_NOT_FOUND`, `LAN_PLUGIN_REGISTRY_XML_MISSING_FIELDS`, `LAN_PLUGIN_INSTALL_UNAVAILABLE`. No hard-coded user-facing English.

- **`REGISTRY-RULES.md`** (new, at repo root) — documents registry purpose, the validation rules from #38, minimal valid `<plugin>` and `plugin.xml` examples, and the disabled-button behaviour added here.

## Rules enforced at runtime

Only the rules that can be checked from the remote `plugin.xml` content are enforced. The rest (repo public, installs cleanly, no conflicts, valid licence) remain manual review checks at PR time.

| Rule | Enforced |
| --- | --- |
| `plugin.xml` exists at `e107_plugins/{folder}/plugin.xml` | yes — fetch fails → null remote |
| `plugin.xml` has `name` + `version` | yes — `validateRemote()` |
| `folder` matches actual directory in repo | indirect — implied by successful fetch |
| `branch` exists | indirect — implied by successful fetch |
| Repo public / installs cleanly / no conflicts / licence | manual review |

`compatibility` is intentionally **not** required here — `parseRegistry()` already falls back to the registry-level value when absent (separate code path).

## Test plan

- [ ] On a test site, the Sitedown Styles card renders with description from `pluginpack.xml` and a **disabled** Install button. Tooltip shows the validation error.
- [ ] All other plugins (chatbox, efiction, forum, spgallery, pm) render unchanged with **active** Install buttons.
- [ ] With `E107_DEBUG_LEVEL > 0`, a debug message appears for non-conforming entries.
- [ ] No new PHP notices/warnings/deprecation messages on PHP 8.1, 8.2, 8.3.
- [ ] Spot-check `validateRemote()`: `null`, `[]`, `'foo'`, `['name'=>'X']`, `['version'=>'1.0']` all return `false`; `['name'=>'X','version'=>'1.0']` returns `true`.
- [ ] Spot-check `getValidationError()`: `null` → `"plugin.xml not found at expected path (e107_plugins/{folder}/plugin.xml)"`; `['name'=>'X']` → `"plugin.xml is missing required fields: version"`.

Closes the runtime-guard work item for #32 (see #33, #35, #38).

---
_Generated by [Claude Code](https://claude.ai/code/session_0168y7DYN6MCuFHaKdXC5aM8)_