### PR TITLE
Security: Validate remote URLs and sanitize marketplace plugin data

### DIFF
--- a/eadmin/plugin.php
+++ b/eadmin/plugin.php
@@ -1485,7 +1485,10 @@ class plugin_online_ui extends e_admin_ui
 				'plugin_repo'         => $row['params']['repo'],
 				'plugin_branch'       => $row['params']['branch'],
 				'plugin_icon'        => vartrue($row['icon'], e_IMAGE."logo_template.png"),
-				'plugin_name'        => stripslashes($row['name']),
+				// Defense-in-depth: escape untrusted remote text on output, even though
+				// e_marketplace already returns these as plain text. The generic 'text'
+				// renderer emits the value into the HTML body unescaped.
+				'plugin_name'        => htmlspecialchars(stripslashes((string) $row['name']), ENT_QUOTES, 'utf-8'),
 				'plugin_description' => $this->truncateSentence(vartrue($row['description'])),
 				'plugin_featured'    => $featured,
 				'plugin_sef'         => '',
@@ -1493,8 +1496,8 @@ class plugin_online_ui extends e_admin_ui
 				'plugin_path'        => $row['folder'],
 				'plugin_date'        => $tp->toDate(strtotime($row['date']), 'relative'),
 				'plugin_category'    => vartrue($row['category'], 'n/a'),
-				'plugin_author'      => vartrue($row['author']),
-				'plugin_version'     => $row['version'],
+				'plugin_author'      => htmlspecialchars((string) vartrue($row['author']), ENT_QUOTES, 'utf-8'),
+				'plugin_version'     => htmlspecialchars((string) $row['version'], ENT_QUOTES, 'utf-8'),
 
 				'plugin_compatible' => $row['compatibility'], // $badge,
 
@@ -1928,7 +1931,7 @@ class plugin_form_online_ui extends e_admin_form_ui
 		}
 
 
-		return '<a title="'.$title.'" '.$disable.' class="e-modal '.$class.'" href="'.$url.'" rel="external" data-loading="'.e_IMAGE.'/generic/loading_32.gif"  data-cache="false" data-modal-caption="'.$modalCaption.'"  target="_blank" >'.$button.'</a>' . $infoButtons;
+		return '<a title="'.$title.'" '.$disable.' class="e-modal '.$class.'" href="'.$url.'" rel="external" data-loading="'.e_IMAGE.'/generic/loading_32.gif"  data-cache="false" data-modal-caption="'.$tp->toAttribute($modalCaption).'"  target="_blank" >'.$button.'</a>' . $infoButtons;
 	//	$dicon = "<a data-toggle='modal' data-bs-toggle='modal' data-modal-caption=\"Downloading ".$data['plugin_name']." ".$data['plugin_version']."\" href='{$url}' data-cache='false' data-target='#uiModal' title='".LAN_DOWNLOAD."' ><img class='top' src='".e_IMAGE_ABS."icons/download_32.png' alt=''  /></a> ";
 
 

--- a/ehandlers/e_marketplace.php
+++ b/ehandlers/e_marketplace.php
@@ -134,6 +134,15 @@ class e_marketplace
 				continue;
 			}
 
+			// Reject poisoned path segments before they can be interpolated into any
+			// remote URL (prevents redirecting fetches off raw.githubusercontent.com).
+			if (!$this->isValidSegment($folder) || !$this->isValidSegment($org)
+				|| !$this->isValidSegment($repo) || !$this->isValidSegment($branch))
+			{
+				e107::getMessage()->addDebug('pluginpack.xml: entry "' . $folder . '" has an invalid path segment, skipped.');
+				continue;
+			}
+
 			// Compatibility gate
 			$compat = isset($attr['compatibility']) ? trim($attr['compatibility']) : '';
 
@@ -287,6 +296,12 @@ class e_marketplace
 	{
 		$url = $this->buildRawUrl($org, $repo, $branch, $folder, $type);
 
+		if ($url === '')
+		{
+			e107::getMessage()->addDebug('pluginpack: invalid path segment — plugin.xml not fetched.');
+			return null;
+		}
+
 		$xml  = e107::getXml();
 		$data = $xml->getRemoteFile($url);
  
@@ -330,23 +345,27 @@ class e_marketplace
 		// // Icon from <adminLinks><link icon="" iconSmall="" primary="true">
 	$base = $this->buildRawBase($org, $repo, $branch, $folder, $type);
 
-	// Screenshots
+	// Screenshots / icon — build candidate URL then validate (http/https only).
+	// The filename segment is attacker-controlled (remote <screenshots><image>);
+	// validation drops anything that could break out of the <img src='...'> attribute.
 	$screenshot = '';
-	if (isset($parsed['screenshots']['image'][0]))
+	if ($base !== '' && isset($parsed['screenshots']['image'][0]) && is_string($parsed['screenshots']['image'][0]))
 	{
-		$screenshot = rtrim($base, '/') . '/' . ltrim($parsed['screenshots']['image'][0], '/');
+		$candidate  = rtrim($base, '/') . '/' . ltrim(trim($parsed['screenshots']['image'][0]), '/');
+		$screenshot = $this->sanitizeRemoteUrl($candidate);
 	}
- 
- 
+
+		// Sanitise at the trust boundary — every remote field leaves this handler clean.
+		$tp = e107::getParser();
 
 		return array(
-			'name'          => isset($rootAttr['name'])          ? trim($rootAttr['name'])          : '',
-			'version'       => isset($rootAttr['version'])       ? trim($rootAttr['version'])       : '',
-			'date'          => isset($rootAttr['date'])          ? trim($rootAttr['date'])           : '',
-			'compatibility' => isset($rootAttr['compatibility']) ? trim($rootAttr['compatibility'])  : '',
-			'author'        => isset($authorAttr['name'])        ? trim($authorAttr['name'])         : '',
-			'authorURL'     => isset($authorAttr['url'])         ? trim($authorAttr['url'])          : '',
-			'description'   => $desc,
+			'name'          => isset($rootAttr['name'])          ? $tp->toText(trim($rootAttr['name']))          : '',
+			'version'       => isset($rootAttr['version'])       ? $tp->toText(trim($rootAttr['version']))       : '',
+			'date'          => isset($rootAttr['date'])          ? $tp->toText(trim($rootAttr['date']))          : '',
+			'compatibility' => isset($rootAttr['compatibility']) ? $tp->toText(trim($rootAttr['compatibility'])) : '',
+			'author'        => isset($authorAttr['name'])        ? $tp->toText(trim($authorAttr['name']))        : '',
+			'authorURL'     => isset($authorAttr['url'])         ? $this->sanitizeRemoteUrl($authorAttr['url'])  : '',
+			'description'   => $tp->toText($desc),
 			'category'      => $category,
 			'icon'          => $screenshot,
 		);
@@ -536,16 +555,66 @@ class e_marketplace
 
 
 	/**
+	 * Validate a GitHub path segment (organization / repo / branch / folder)
+	 * before interpolating it into a remote URL. Anything outside the allowed
+	 * character set is rejected so a poisoned pluginpack.xml cannot redirect
+	 * fetches off raw.githubusercontent.com or inject path traversal.
+	 *
+	 * @param  string $segment
+	 * @return bool
+	 */
+	private function isValidSegment($segment)
+	{
+		return is_string($segment) && $segment !== '' && (bool) preg_match('/^[A-Za-z0-9._-]+$/', $segment);
+	}
+
+
+	/**
+	 * Validate an untrusted remote URL (icon / screenshot / author URL).
+	 * Accepts only syntactically valid absolute http(s) URLs. Rejects
+	 * javascript:, data:, schemeless values and any attribute-breaking
+	 * characters (quotes, spaces, angle brackets — all refused by
+	 * FILTER_VALIDATE_URL). Returns '' when invalid so callers can drop it.
+	 *
+	 * @param  string $url
+	 * @return string
+	 */
+	private function sanitizeRemoteUrl($url)
+	{
+		$url = trim((string) $url);
+
+		if ($url === '' || filter_var($url, FILTER_VALIDATE_URL) === false)
+		{
+			return '';
+		}
+
+		$scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+
+		if ($scheme !== 'http' && $scheme !== 'https')
+		{
+			return '';
+		}
+
+		return $url;
+	}
+
+
+	/**
 	 * Build zip download URL.
 	 * https://github.com/{org}/{repo}/archive/refs/heads/{branch}.zip
 	 *
 	 * @param  string $org
 	 * @param  string $repo
 	 * @param  string $branch
-	 * @return string
+	 * @return string  Empty string when any segment is invalid.
 	 */
 	private function buildDownloadUrl($org, $repo, $branch)
 	{
+		if (!$this->isValidSegment($org) || !$this->isValidSegment($repo) || !$this->isValidSegment($branch))
+		{
+			return '';
+		}
+
 		return 'https://github.com/' . $org . '/' . $repo
 			. '/archive/refs/heads/' . $branch . '.zip';
 	}
@@ -564,6 +633,12 @@ class e_marketplace
 	 */
 	private function buildRawBase($org, $repo, $branch, $folder, $type = 'plugin')
 	{
+		if (!$this->isValidSegment($org) || !$this->isValidSegment($repo)
+			|| !$this->isValidSegment($branch) || !$this->isValidSegment($folder))
+		{
+			return '';
+		}
+
 		$dir = ($type === 'theme') ? 'e107_themes' : 'e107_plugins';
 
 		return 'https://raw.githubusercontent.com/'
@@ -583,7 +658,14 @@ class e_marketplace
 	 */
 	private function buildRawUrl($org, $repo, $branch, $folder, $type = 'plugin')
 	{
-		return $this->buildRawBase($org, $repo, $branch, $folder, $type) . '/plugin.xml';
+		$base = $this->buildRawBase($org, $repo, $branch, $folder, $type);
+
+		if ($base === '')
+		{
+			return '';
+		}
+
+		return $base . '/plugin.xml';
 	}
 
 }


### PR DESCRIPTION
## Summary
This PR hardens the marketplace plugin handler against URL injection and XSS attacks by validating GitHub path segments before URL interpolation and sanitizing all untrusted remote data at the trust boundary.

## Key Changes

**ehandlers/e_marketplace.php:**
- Added `isValidSegment()` method to validate GitHub path segments (org/repo/branch/folder) using strict character whitelist (`[A-Za-z0-9._-]+`), preventing path traversal and off-domain redirects
- Added `sanitizeRemoteUrl()` method to validate untrusted remote URLs (icons, screenshots, author URLs) — accepts only valid http(s) absolute URLs, rejects javascript:, data:, schemeless, and attribute-breaking characters
- Integrated segment validation into `parseRegistry()` to reject poisoned pluginpack.xml entries before URL construction
- Added URL validation checks in `fetchRemotePluginXml()`, `buildDownloadUrl()`, `buildRawBase()`, and `buildRawUrl()` methods
- Sanitized all remote XML fields using `$tp->toText()` for text content and `sanitizeRemoteUrl()` for URLs (name, version, date, compatibility, author, authorURL, description, icon/screenshot)
- Added validation for screenshot image filename before URL construction to prevent attribute injection

**eadmin/plugin.php:**
- Added output escaping for untrusted remote fields (`plugin_name`, `plugin_author`, `plugin_version`) using `htmlspecialchars()` with `ENT_QUOTES` — defense-in-depth even though marketplace handler now returns plain text
- Added `$tp->toAttribute()` escaping for modal caption to prevent attribute injection

## Implementation Details
- Validation occurs at the trust boundary (marketplace handler) so all remote data leaves sanitized
- URL validation uses PHP's `FILTER_VALIDATE_URL` combined with scheme whitelist to prevent protocol-based attacks
- Path segment validation uses strict regex to ensure GitHub URLs cannot be redirected or manipulated
- Output escaping in plugin.php provides defense-in-depth against any future sanitization gaps

https://claude.ai/code/session_01Y7pCSHiFzYVE84BLRuYYyF