### PR TITLE
Remove e107.org admin feed from dashboard styles (Lite #88)

### DIFF
--- a/eadmin/includes/dashboard.php
+++ b/eadmin/includes/dashboard.php
@@ -25,7 +25,9 @@
 	//define('FLEXPANEL_ENABLED', $flepanelEnabled);
 	//change: allow use flex always, not depends on personalization access
 	define('FLEXPANEL_ENABLED', true);
-	//define('ADMINFEEDMORE', 'https://e107.org/blog');
+	//LITE-SKIP Lite removes the e107.org admin RSS feed entirely (no phone-home).
+	//LITE-SKIP ADMINFEEDMORE dropped. See Lite #88.
+	//LITE-SKIP define('ADMINFEEDMORE', 'https://e107.org/blog');
 
 	// Save rearranged menus to user.
 	if (e_AJAX_REQUEST) {
@@ -244,31 +246,33 @@
 		 */
 		public function core_infopanel_news($options = array())
 		{
-			// $ns = e107::getRender();
-
-			// $dashboardUniqueId 	= varset($options['uniqueId'], time());
-			// $dashboardStyle		= varset($options['style'], 'flexbox');
-
-			// $newsTabs = array();
-			// $newsTabs['coreFeed'] = array('caption' => LAN_GENERAL, 'text' => "<div id='e-adminfeed' style='min-height:300px'></div><div class='right'><a rel='external' href='" . ADMINFEEDMORE . "'>" . LAN_MORE . "</a></div>");
-			// $newsTabs['pluginFeed'] = array('caption' => LAN_PLUGIN, 'text' => "<div id='e-adminfeed-plugin'></div>");
-			// $newsTabs['themeFeed'] = array('caption' => LAN_THEMES, 'text' => "<div id='e-adminfeed-theme'></div>");
-
-			// $code = "
-			// jQuery(function($){
-			// 	$('#e-adminfeed').load('" . e_ADMIN . "admin.php?mode=core&type=feed');
-			// 	$('#e-adminfeed-plugin').load('" . e_ADMIN . "admin.php?mode=addons&type=plugin');
-			// 	$('#e-adminfeed-theme').load('" . e_ADMIN . "admin.php?mode=addons&type=theme');	
-			// });
-			// ";
-			// e107::js('inline', $code, 'jquery');
-
-			// $ns->setStyle($dashboardStyle);
-			// $ns->setUniqueId($dashboardUniqueId);
-
-			// $coreInfoPanelNews = $ns->tablerender(LAN_LATEST_e107_NEWS, e107::getForm()->tabs($newsTabs, array('active' => 'coreFeed')), $dashboardUniqueId, true);
-
-			// return $coreInfoPanelNews;
+			//LITE-SKIP Lite removes the e107.org admin RSS feed entirely (no phone-home).
+			//LITE-SKIP e-adminfeed panel + ADMINFEEDMORE dropped. See Lite #88.
+			//LITE-SKIP $ns = e107::getRender();
+			//LITE-SKIP
+			//LITE-SKIP $dashboardUniqueId 	= varset($options['uniqueId'], time());
+			//LITE-SKIP $dashboardStyle		= varset($options['style'], 'flexbox');
+			//LITE-SKIP
+			//LITE-SKIP $newsTabs = array();
+			//LITE-SKIP $newsTabs['coreFeed'] = array('caption' => LAN_GENERAL, 'text' => "<div id='e-adminfeed' style='min-height:300px'></div><div class='right'><a rel='external' href='" . ADMINFEEDMORE . "'>" . LAN_MORE . "</a></div>");
+			//LITE-SKIP $newsTabs['pluginFeed'] = array('caption' => LAN_PLUGIN, 'text' => "<div id='e-adminfeed-plugin'></div>");
+			//LITE-SKIP $newsTabs['themeFeed'] = array('caption' => LAN_THEMES, 'text' => "<div id='e-adminfeed-theme'></div>");
+			//LITE-SKIP
+			//LITE-SKIP $code = "
+			//LITE-SKIP jQuery(function($){
+			//LITE-SKIP 	$('#e-adminfeed').load('" . e_ADMIN . "admin.php?mode=core&type=feed');
+			//LITE-SKIP 	$('#e-adminfeed-plugin').load('" . e_ADMIN . "admin.php?mode=addons&type=plugin');
+			//LITE-SKIP 	$('#e-adminfeed-theme').load('" . e_ADMIN . "admin.php?mode=addons&type=theme');	
+			//LITE-SKIP });
+			//LITE-SKIP ";
+			//LITE-SKIP e107::js('inline', $code, 'jquery');
+			//LITE-SKIP
+			//LITE-SKIP $ns->setStyle($dashboardStyle);
+			//LITE-SKIP $ns->setUniqueId($dashboardUniqueId);
+			//LITE-SKIP
+			//LITE-SKIP $coreInfoPanelNews = $ns->tablerender(LAN_LATEST_e107_NEWS, e107::getForm()->tabs($newsTabs, array('active' => 'coreFeed')), $dashboardUniqueId, true);
+			//LITE-SKIP
+			//LITE-SKIP return $coreInfoPanelNews;
 		}
 
 		/**

--- a/eadmin/includes/flexpanel.php
+++ b/eadmin/includes/flexpanel.php
@@ -219,19 +219,21 @@ class adminstyle_flexpanel extends adminstyle_infopanel
 
 
 		// --------------------- e107 News --------------------------------
-		$newsTabs = array();
-		$newsTabs['coreFeed'] = array('caption' => LAN_GENERAL, 'text' => "<div id='e-adminfeed' style='min-height:300px'></div><div class='right'><a rel='external' href='" . ADMINFEEDMORE . "'>" . LAN_MORE . "</a></div>");
-		$newsTabs['pluginFeed'] = array('caption' => LAN_PLUGIN, 'text' => "<div id='e-adminfeed-plugin'></div>");
-		$newsTabs['themeFeed'] = array('caption' => LAN_THEMES, 'text' => "<div id='e-adminfeed-theme'></div>");
-		$ns->setStyle('flexpanel');
-		$ns->setUniqueId('core-infopanel_news');
-		$coreInfoPanelNews = $ns->tablerender(LAN_LATEST_e107_NEWS, e107::getForm()->tabs($newsTabs, array('active' => 'coreFeed')), "core-infopanel_news", true);
-		$info = $this->getMenuPosition('core-infopanel_news');
-		if (!isset($panels[$info['area']][$info['weight']]))
-		{
-			$panels[$info['area']][$info['weight']] = '';
-		}
-		$panels[$info['area']][$info['weight']] .= $coreInfoPanelNews;
+		//LITE-SKIP Lite removes the e107.org admin RSS feed entirely (no phone-home).
+		//LITE-SKIP e-adminfeed panel + ADMINFEEDMORE dropped. See Lite #88.
+		//LITE-SKIP $newsTabs = array();
+		//LITE-SKIP $newsTabs['coreFeed'] = array('caption' => LAN_GENERAL, 'text' => "<div id='e-adminfeed' style='min-height:300px'></div><div class='right'><a rel='external' href='" . ADMINFEEDMORE . "'>" . LAN_MORE . "</a></div>");
+		//LITE-SKIP $newsTabs['pluginFeed'] = array('caption' => LAN_PLUGIN, 'text' => "<div id='e-adminfeed-plugin'></div>");
+		//LITE-SKIP $newsTabs['themeFeed'] = array('caption' => LAN_THEMES, 'text' => "<div id='e-adminfeed-theme'></div>");
+		//LITE-SKIP $ns->setStyle('flexpanel');
+		//LITE-SKIP $ns->setUniqueId('core-infopanel_news');
+		//LITE-SKIP $coreInfoPanelNews = $ns->tablerender(LAN_LATEST_e107_NEWS, e107::getForm()->tabs($newsTabs, array('active' => 'coreFeed')), "core-infopanel_news", true);
+		//LITE-SKIP $info = $this->getMenuPosition('core-infopanel_news');
+		//LITE-SKIP if (!isset($panels[$info['area']][$info['weight']]))
+		//LITE-SKIP {
+			//LITE-SKIP $panels[$info['area']][$info['weight']] = '';
+		//LITE-SKIP }
+		//LITE-SKIP $panels[$info['area']][$info['weight']] .= $coreInfoPanelNews;
 
 
 		// --------------------- Website Status ---------------------------

--- a/eadmin/includes/infopanel.php
+++ b/eadmin/includes/infopanel.php
@@ -16,7 +16,9 @@ if (!defined('e107_INIT'))
 }
 
 
-//LITE MODIFICATION define('ADMINFEEDMORE', 'https://e107.org/blog');
+//LITE-SKIP Lite removes the e107.org admin RSS feed entirely (no phone-home).
+//LITE-SKIP ADMINFEEDMORE dropped. See Lite #88.
+//LITE-SKIP define('ADMINFEEDMORE', 'https://e107.org/blog');
 
 
 
@@ -280,13 +282,15 @@ class adminstyle_infopanel
 	
 	//  ------------------------------- e107 News --------------------------------
 
-		//LITE MODIFICATION $newsTabs = array();
-		//$newsTabs['coreFeed'] = array('caption'=>LAN_GENERAL,'text'=>"<div id='e-adminfeed' style='min-height:300px'></div><div class='right'><a rel='external' href='".ADMINFEEDMORE."'>".LAN_MORE."</a></div>");
-		//$newsTabs['pluginFeed'] = array('caption'=>LAN_PLUGIN,'text'=>"<div id='e-adminfeed-plugin'></div>");
-		//$newsTabs['themeFeed'] = array('caption'=>LAN_THEMES,'text'=>"<div id='e-adminfeed-theme'></div>");
-
-		//$text2 = $ns->tablerender(LAN_LATEST_e107_NEWS,e107::getForm()->tabs($newsTabs, array('active'=>'coreFeed')),"core-infopanel_news",true);
-	
+		//LITE-SKIP Lite removes the e107.org admin RSS feed entirely (no phone-home).
+		//LITE-SKIP e-adminfeed panel + ADMINFEEDMORE dropped. See Lite #88.
+		//LITE-SKIP $newsTabs = array();
+		//LITE-SKIP $newsTabs['coreFeed'] = array('caption'=>LAN_GENERAL,'text'=>"<div id='e-adminfeed' style='min-height:300px'></div><div class='right'><a rel='external' href='".ADMINFEEDMORE."'>".LAN_MORE."</a></div>");
+		//LITE-SKIP $newsTabs['pluginFeed'] = array('caption'=>LAN_PLUGIN,'text'=>"<div id='e-adminfeed-plugin'></div>");
+		//LITE-SKIP $newsTabs['themeFeed'] = array('caption'=>LAN_THEMES,'text'=>"<div id='e-adminfeed-theme'></div>");
+		//LITE-SKIP
+		//LITE-SKIP $text2 = $ns->tablerender(LAN_LATEST_e107_NEWS,e107::getForm()->tabs($newsTabs, array('active'=>'coreFeed')),"core-infopanel_news",true);
+		//LITE-SKIP
 	
 	
 	


### PR DESCRIPTION
Lite cancels the e107.org admin RSS feed entirely (no phone-home). Unify the disabled feed across both mutually-exclusive admin styles using //LITE-SKIP markers so sync passes can spot them:

- flexpanel.php: //LITE-SKIP the e107 News block (coreFeed/pluginFeed/ themeFeed + tablerender). It still referenced ADMINFEEDMORE, which is undefined in Lite -> fatal on PHP 8 when adminstyle='flexpanel'.
- dashboard.php: convert the ad-hoc-commented ADMINFEEDMORE define and core_infopanel_news() feed body to the same //LITE-SKIP treatment.
- infopanel.php: convert the remaining ad-hoc-commented ADMINFEEDMORE define and news block (parent class of flexpanel) so every ADMINFEEDMORE reference in eadmin/ lives inside a //LITE-SKIP line.
 