### PR TITLE
Restore Lite default (No) for delete tables on plugin uninstall

### DIFF
--- a/eadmin/plugin.php
+++ b/eadmin/plugin.php
@@ -824,7 +824,12 @@ class plugin_ui extends e_admin_ui
 					'label'			=> EPL_ADLAN_57,
 					'helpText'		=> EPL_ADLAN_58,
 					'itemList'		=> array(1=>LAN_YES,0=>LAN_NO),
-					'itemDefault' 	=> 1
+					// LITE MODIFICATION: default 0 (No). Upstream defaults to 1 (Yes),
+					// which pre-selects destructive table deletion on uninstall — easy
+					// to confirm by accident and lose plugin data. Lite makes the
+					// non-destructive choice the default.
+					// Revert condition: if upstream changes this default to 0.
+					'itemDefault' 	=> 0
 			);
 
 			if ($userclasses)


### PR DESCRIPTION
Upstream defaults the uninstall "delete tables" option to Yes. The 2.4.0.2 sync overwrote Lite's safer No default. Re-apply it and add a LITE MODIFICATION marker at the call site so future syncs don't silently revert it again.
